### PR TITLE
Separate RM and SM execution roles

### DIFF
--- a/components/aws/sagemaker/Changelog.md
+++ b/components/aws/sagemaker/Changelog.md
@@ -4,6 +4,12 @@ The version of the AWS SageMaker Components is determined by the docker image ta
 Repository:  https://hub.docker.com/repository/docker/amazon/aws-sagemaker-kfp-components
 
 ---------------------------------------------
+**Change log for version 1.1.0**
+- Add SageMaker RLEstimator component
+- Add RoboMaker create/delete simulation application, cerate simulation job components
+
+> Pull requests : [#4813](https://github.com/kubeflow/pipelines/pull/4813/)
+
 **Change log for version 1.0.0**
 - First release to guarantee backward compatibility within major version
 - Internally refactored components

--- a/components/aws/sagemaker/common/spec_input_parsers.py
+++ b/components/aws/sagemaker/common/spec_input_parsers.py
@@ -44,16 +44,16 @@ class SpecInputParsers:
     def yaml_or_json_list(value):
         """Parses a YAML or JSON list to a Python list."""
         parsed = SpecInputParsers._yaml_or_json_str(value)
-        if not isinstance(parsed, List):
-            raise ArgumentTypeError(f"{value} is not a list")
+        if parsed is not None and not isinstance(parsed, List):
+            raise ArgumentTypeError(f"{value} (type {type(value)}) is not a list")
         return parsed
 
     @staticmethod
     def yaml_or_json_dict(value):
         """Parses a YAML or JSON dictionary to a Python dictionary."""
         parsed = SpecInputParsers._yaml_or_json_str(value)
-        if not isinstance(parsed, Dict):
-            raise ArgumentTypeError(f"{value} is not a dictionary")
+        if parsed is not None and not isinstance(parsed, Dict):
+            raise ArgumentTypeError(f"{value} (type {type(value)}) is not a dictionary")
         return parsed
 
     @staticmethod

--- a/components/aws/sagemaker/tests/integration_tests/.env.example
+++ b/components/aws/sagemaker/tests/integration_tests/.env.example
@@ -6,6 +6,7 @@
 REGION=us-east-1
 
 SAGEMAKER_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole-Example
+ROBOMAKER_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/service-role/AmazonRoboMaker-ExecutionRole-Example
 S3_DATA_BUCKET=my-data-bucket
 
 # If you hope to use an existing EKS cluster, rather than creating a new one.

--- a/components/aws/sagemaker/tests/integration_tests/README.md
+++ b/components/aws/sagemaker/tests/integration_tests/README.md
@@ -8,7 +8,7 @@
 ## Creating S3 buckets with datasets
 
 1. In the following Python script, change the bucket name and run the [`s3_sample_data_creator.py`](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/mnist-kmeans-sagemaker#the-sample-dataset) to create an S3 bucket with the sample mnist dataset in the region where you want to run the tests.
-2. To prepare the dataset for the SageMaker GroundTruth Component test, follow the steps in the `[GroundTruth Sample README](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/ground_truth_pipeline_demo#prep-the-dataset-label-categories-and-ui-template)`.
+2. To prepare the dataset for the SageMaker GroundTruth Component test, follow the steps in the [GroundTruth Sample README](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/ground_truth_pipeline_demo#prep-the-dataset-label-categories-and-ui-template).
 3. To prepare the processing script for the SageMaker Processing Component tests, upload the `scripts/kmeans_preprocessing.py` script to your bucket. This can be done by replacing `<my-bucket>` with your bucket name and running `aws s3 cp scripts/kmeans_preprocessing.py s3://<my-bucket>/mnist_kmeans_example/processing_code/kmeans_preprocessing.py`
 4. Prepare RoboMaker Simulation App sources and Simulation Job sources and place them in the data bucket under the `/robomaker` key. The easiest way to create the files you need is to follow the notebooks outlined in the [RoboMaker Samples README](https://github.com/kubeflow/pipelines/tree/master/samples/contrib/aws-samples/robomaker_simulation/README.md).
     The files in the `/robomaker` directory on S3 should follow this pattern:
@@ -27,7 +27,7 @@
     1. Configure the AWS credentials fields with those of your IAM User.
     1. Update the `SAGEMAKER_EXECUTION_ROLE_ARN` with that of your role created earlier.
     1. Update the `S3_DATA_BUCKET` parameter with the name of the bucket created earlier.
-    1. Update the `ROBOMAKER_SECURITY_GROUPS` and `ROBOMAKER_SUBNETS` parameters with the resources you have created to run the RoboMaker integration tests in.
+    1. (Optional) Update the `ROBOMAKER_SECURITY_GROUPS` and `ROBOMAKER_SUBNETS` parameters with the resources you have created to run the RoboMaker integration tests in.
     1. (Optional) If you have already created an EKS cluster for testing, replace the `EKS_EXISTING_CLUSTER` field with it's name.
 1. Build the image by doing the following:
     1. Navigate to the root of this github directory.

--- a/components/aws/sagemaker/tests/integration_tests/README.md
+++ b/components/aws/sagemaker/tests/integration_tests/README.md
@@ -27,7 +27,6 @@
     1. Configure the AWS credentials fields with those of your IAM User.
     1. Update the `SAGEMAKER_EXECUTION_ROLE_ARN` with that of your role created earlier.
     1. Update the `S3_DATA_BUCKET` parameter with the name of the bucket created earlier.
-    1. (Optional) Update the `ROBOMAKER_SECURITY_GROUPS` and `ROBOMAKER_SUBNETS` parameters with the resources you have created to run the RoboMaker integration tests in.
     1. (Optional) If you have already created an EKS cluster for testing, replace the `EKS_EXISTING_CLUSTER` field with it's name.
 1. Build the image by doing the following:
     1. Navigate to the root of this github directory.

--- a/components/aws/sagemaker/tests/integration_tests/conftest.py
+++ b/components/aws/sagemaker/tests/integration_tests/conftest.py
@@ -16,7 +16,10 @@ def pytest_addoption(parser):
         help="AWS region where test will run",
     )
     parser.addoption(
-        "--role-arn", required=True, help="SageMaker execution IAM role ARN",
+        "--sagemaker-role-arn", required=True, help="SageMaker execution IAM role ARN",
+    )
+    parser.addoption(
+        "--robomaker-role-arn", required=True, help="RoboMaker execution IAM role ARN",
     )
     parser.addoption(
         "--assume-role-arn",
@@ -73,9 +76,14 @@ def assume_role_arn(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def role_arn(request):
-    os.environ["ROLE_ARN"] = request.config.getoption("--role-arn")
-    return request.config.getoption("--role-arn")
+def sagemaker_role_arn(request):
+    os.environ["SAGEMAKER_ROLE_ARN"] = request.config.getoption("--sagemaker-role-arn")
+    return request.config.getoption("--sagemaker-role-arn")
+
+@pytest.fixture(scope="session", autouse=True)
+def robomaker_role_arn(request):
+    os.environ["ROBOMAKER_ROLE_ARN"] = request.config.getoption("--robomaker-role-arn")
+    return request.config.getoption("--robomaker-role-arn")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/assume-role-processing/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/assume-role-processing/config.yaml
@@ -44,4 +44,4 @@ Arguments:
   instance_count: 1
   volume_size: 50
   max_run_time: 1800
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/assume-role-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/assume-role-training/config.yaml
@@ -30,4 +30,4 @@ Arguments:
   spot_instance: "False"
   max_wait_time: 3600
   checkpoint_config: "{}"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/fsx-mnist-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/fsx-mnist-training/config.yaml
@@ -33,4 +33,4 @@ Arguments:
   spot_instance: "False"
   max_wait_time: 3600
   checkpoint_config: "{}"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/image-classification-groundtruth/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/image-classification-groundtruth/config.yaml
@@ -4,7 +4,7 @@ Timeout: 300
 StatusToCheck: 'running'
 Arguments:
   region: ((REGION))
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   ground_truth_train_job_name: 'image-labeling'
   ground_truth_label_attribute_name: 'category'
   ground_truth_train_manifest_location: 's3://((DATA_BUCKET))/mini-image-classification/ground-truth-demo/train.manifest'

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-algo-mnist-processing/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-algo-mnist-processing/config.yaml
@@ -43,4 +43,4 @@ Arguments:
   instance_count: 1
   volume_size: 50
   max_run_time: 1800
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-batch-transform/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-batch-transform/config.yaml
@@ -11,7 +11,7 @@ Arguments:
   instance_type: ml.m4.xlarge
   instance_count: 1
   network_isolation: "True"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   data_input: s3://((DATA_BUCKET))/mnist_kmeans_example/input
   data_type: S3Prefix
   content_type: text/csv

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-endpoint/config.yaml
@@ -17,5 +17,5 @@ Arguments:
   instance_type_1: ml.m4.xlarge
   initial_instance_count_1: 1
   network_isolation: "True"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-hpo/config.yaml
@@ -53,4 +53,4 @@ Arguments:
   output_location: s3://((DATA_BUCKET))/mnist_kmeans_example/output
   network_isolation: "True"
   max_wait_time: 3600
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-model/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-model/config.yaml
@@ -7,5 +7,5 @@ Arguments:
   image: ((KMEANS_REGISTRY)).dkr.ecr.((REGION)).amazonaws.com/kmeans:1
   model_artifact_url: s3://((DATA_BUCKET))/mnist_kmeans_example/model/kmeans-mnist-model/model.tar.gz
   network_isolation: "True"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-update-endpoint/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/kmeans-mnist-update-endpoint/config.yaml
@@ -19,6 +19,6 @@ Arguments:
   instance_type_2: ml.m5.xlarge
   initial_instance_count_1: 1
   network_isolation: "True"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   update_endpoint: "True"
   

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/rlestimator-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/rlestimator-training/config.yaml
@@ -4,14 +4,14 @@ Timeout: 900
 ExpectedTrainingImage: 462105765813.dkr.ecr.((REGION)).amazonaws.com/sagemaker-rl-ray-container:ray-0.8.5-tf-cpu-py36
 Arguments:
   region: ((REGION))
-  role: ((ASSUME_ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))
   entry_point: "train_news_vendor.py"
   metric_definitions: "[]"
   hyperparameters: "{}"
   source_dir: s3://((DATA_BUCKET))/rlestimator/sourcedir.tar.gz
   max_run: 300
-  job_name: rlestimator-pipeline-int-test
-  model_artifact_path: s3://((DATA_BUCKET))/
+  job_name: rlestimator-test
+  model_artifact_path: s3://((DATA_BUCKET))/rlestimator/output/
   instance_count: 1
   instance_type: ml.c5.2xlarge
   framework: tensorflow

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/robomaker-simulation-job/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/robomaker-simulation-job/config.yaml
@@ -17,6 +17,4 @@ Arguments:
       ROS_AWS_REGION: ((REGION))
       MARKOV_PRESET_FILE: "object_tracker.py"
       NUMBER_OF_ROLLOUT_WORKERS: "1"
-  role: ((ROLE_ARN))
-  vpc_security_group_ids: ((ROBOMAKER_SECURITY_GROUPS))
-  vpc_subnets: ((ROBOMAKER_SUBNETS))
+  role: ((ROBOMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/simple-mnist-training/config.yaml
@@ -29,4 +29,4 @@ Arguments:
   spot_instance: "False"
   max_wait_time: 3600
   checkpoint_config: "{}"
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/spot-sample-pipeline-training/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/spot-sample-pipeline-training/config.yaml
@@ -22,4 +22,4 @@ Arguments:
   checkpoint_config:
     S3Uri: s3://((DATA_BUCKET))/mnist_kmeans_example/train-checkpoints
   model_artifact_path: s3://((DATA_BUCKET))/mnist_kmeans_example/output
-  role: ((ROLE_ARN))
+  role: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/resources/config/xgboost-mnist-trainingjob-debugger/config.yaml
+++ b/components/aws/sagemaker/tests/integration_tests/resources/config/xgboost-mnist-trainingjob-debugger/config.yaml
@@ -4,4 +4,4 @@ Timeout: 3600
 ExpectedTrainingImage: 683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:0.90-2-cpu-py3
 Arguments:
   bucket_name: ((DATA_BUCKET))
-  role_arn: ((ROLE_ARN))
+  role_arn: ((SAGEMAKER_ROLE_ARN))

--- a/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
+++ b/components/aws/sagemaker/tests/integration_tests/scripts/run_integration_tests
@@ -34,8 +34,7 @@ PYTEST_MARKER=${PYTEST_MARKER:-""}
 S3_DATA_BUCKET=${S3_DATA_BUCKET:-""}
 SAGEMAKER_EXECUTION_ROLE_ARN=${SAGEMAKER_EXECUTION_ROLE_ARN:-""}
 ASSUMED_ROLE_NAME=${ASSUMED_ROLE_NAME:-""}
-ROBOMAKER_SECURITY_GROUPS=${ROBOMAKER_SECURITY_GROUPS:-""}
-ROBOMAKER_SUBNETS=${ROBOMAKER_SUBNETS:-""}
+ROBOMAKER_EXECUTION_ROLE_ARN=${ROBOMAKER_EXECUTION_ROLE_ARN:-""}
 
 SKIP_FSX_TESTS=${SKIP_FSX_TESTS:-"false"}
 
@@ -259,9 +258,10 @@ install_kfp
 [ "${SKIP_KFP_OIDC_SETUP}" == "false" ] && install_oidc_role
 generate_assumed_role
 
-pytest_args=( --region "${REGION}" --role-arn "${SAGEMAKER_EXECUTION_ROLE_ARN}" \
+pytest_args=( --region "${REGION}" --sagemaker-role-arn "${SAGEMAKER_EXECUTION_ROLE_ARN}" \
   --s3-data-bucket "${S3_DATA_BUCKET}" --kfp-namespace "${KFP_NAMESPACE}" \
-  --minio-service-port "${MINIO_LOCAL_PORT}" --assume-role-arn "${ASSUMED_ROLE_ARN}")
+  --minio-service-port "${MINIO_LOCAL_PORT}" --assume-role-arn "${ASSUMED_ROLE_ARN}" \
+  --robomaker-role-arn "${ROBOMAKER_EXECUTION_ROLE_ARN}")
 
 if [[ "${SKIP_FSX_TESTS}" == "true" ]]; then
   pytest_args+=( -m "not fsx_test" )

--- a/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
+++ b/components/aws/sagemaker/tests/integration_tests/utils/__init__.py
@@ -15,8 +15,12 @@ def get_region():
     return os.environ.get("AWS_REGION")
 
 
-def get_role_arn():
-    return os.environ.get("ROLE_ARN")
+def get_sagemaker_role_arn():
+    return os.environ.get("SAGEMAKER_ROLE_ARN")
+
+
+def get_robomaker_role_arn():
+    return os.environ.get("ROBOMAKER_ROLE_ARN")
 
 
 def get_s3_data_bucket():
@@ -41,14 +45,6 @@ def get_fsx_security_group():
 
 def get_fsx_id():
     return os.environ.get("FSX_ID")
-
-
-def get_robomaker_security_groups():
-    return json.dumps(os.environ.get("ROBOMAKER_SECURITY_GROUPS").split(","))
-
-
-def get_robomaker_subnets():
-    return json.dumps(os.environ.get("ROBOMAKER_SUBNETS").split(","))
 
 
 def get_algorithm_image_registry(framework, region, version=None):
@@ -91,7 +87,7 @@ def replace_placeholders(input_filename, output_filename):
     region = get_region()
     variables_to_replace = {
         "((REGION))": region,
-        "((ROLE_ARN))": get_role_arn(),
+        "((SAGEMAKER_ROLE_ARN))": get_sagemaker_role_arn(),
         "((DATA_BUCKET))": get_s3_data_bucket(),
         "((KMEANS_REGISTRY))": get_algorithm_image_registry("kmeans", region, "1"),
         "((XGBOOST_REGISTRY))": get_algorithm_image_registry(
@@ -102,8 +98,7 @@ def replace_placeholders(input_filename, output_filename):
         "((FSX_SUBNET))": get_fsx_subnet(),
         "((FSX_SECURITY_GROUP))": get_fsx_security_group(),
         "((ASSUME_ROLE_ARN))": get_assume_role_arn(),
-        "((ROBOMAKER_SECURITY_GROUPS))": get_robomaker_security_groups(),
-        "((ROBOMAKER_SUBNETS))": get_robomaker_subnets(),
+        "((ROBOMAKER_ROLE_ARN))": get_robomaker_role_arn(),
     }
 
     filedata = ""


### PR DESCRIPTION
**Description of your changes:**
Minor changes to ensure working integration tests and smoother release process:
- Removed RoboMaker security group and subnet settings (want to default to shadow VPC if possible)
- Separated SageMaker and RoboMaker execution roles
- Added a changelog update for coming release (more process will come later)
